### PR TITLE
Fix command mode character deletion bug

### DIFF
--- a/screen/screen.go
+++ b/screen/screen.go
@@ -258,9 +258,15 @@ func executeCommandMode(ev *tcell.EventKey, quit chan struct{}) {
 	case tcell.KeyEnter:
 		executeCommand(quit)
 	case tcell.KeyDEL:
-		sz := len(command)
-		command = command[:sz-1]
-		if sz == 1 {
+		if xCommandCursor <= 1 && len(command) > 1 {
+			break
+		}
+		runeCopy := []rune(command)
+		copy(runeCopy[xCommandCursor-1:], runeCopy[xCommandCursor:])
+		shrinkSize := len(runeCopy) - 1
+		runeCopy = runeCopy[:shrinkSize]
+		command = string(runeCopy)
+		if shrinkSize == 0 {
 			removeHighlighting()
 			mode = normalMode
 		}


### PR DESCRIPTION
Previously, whenever the user would click the delete button when in command mode, the last element of the string would be removed. This fix makes it so that the character before the cursor is always removed, just like insertion mode.