### PR TITLE
Fix delete rest of line visual bug

### DIFF
--- a/screen/screen.go
+++ b/screen/screen.go
@@ -256,6 +256,9 @@ func executeNormalMode(info *info, ev *tcell.EventKey) {
 			for i := info.xCursor; i <= info.xCursor+requiredUpdates; i++ {
 				info.screen.SetContent(i, info.yCursor, ' ', nil, terminalStyle)
 			}
+			if requiredUpdates == 1 && info.xCursor > 0 {
+				actionLeft(info)
+			}
 		}
 	}
 }

--- a/screen/screen.go
+++ b/screen/screen.go
@@ -256,7 +256,7 @@ func executeNormalMode(info *info, ev *tcell.EventKey) {
 			for i := info.xCursor; i <= info.xCursor+requiredUpdates; i++ {
 				info.screen.SetContent(i, info.yCursor, ' ', nil, terminalStyle)
 			}
-			if requiredUpdates == 1 && info.xCursor > 0 {
+			if info.xCursor > 0 {
 				actionLeft(info)
 			}
 		}


### PR DESCRIPTION
Fix a bug in which the 'D' command would not cause the cursor to move to the left.

Relates to issue #51 